### PR TITLE
Add REACT_APP_SOURCE_VERSION to environment variable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -65,7 +65,7 @@ chmod -f +x $dir/bin/{detect,compile,release}
 framework=$($dir/bin/detect $1)
 
 echo "~~~~~> Added source version to env"
-export REACT_APP_SOURCE_VERSION=$SOURCE_VERSION
+echo $SOURCE_VERSION > $ENV_DIR/REACT_APP_SOURCE_VERSION
 
 if [ $? == 0 ]; then
   echo "=====> Detected Framework: $framework"

--- a/bin/compile
+++ b/bin/compile
@@ -64,7 +64,7 @@ chmod -f +x $dir/bin/{detect,compile,release}
 
 framework=$($dir/bin/detect $1)
 
-echo "~~~~~> Added source version to env"
+echo "~~~~~> Add SOURCE_VERSION to env"
 echo $SOURCE_VERSION > $ENV_DIR/REACT_APP_SOURCE_VERSION
 
 if [ $? == 0 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -64,6 +64,9 @@ chmod -f +x $dir/bin/{detect,compile,release}
 
 framework=$($dir/bin/detect $1)
 
+echo "~~~~~> Added source version to env"
+export REACT_APP_SOURCE_VERSION=$SOURCE_VERSION
+
 if [ $? == 0 ]; then
   echo "=====> Detected Framework: $framework"
   $dir/bin/compile $BUILD_DIR $CACHE_DIR $ENV_DIR


### PR DESCRIPTION
We need to send the SOURCE_VERSION/release version to Sentry with every issue. For this reason, `SOURCE_VERSION` should be exposed on the client side. To achieve this, we need to add it as an environment variable in the build step from where the build pack will automatically append it to the JS bundle. 

As of now, build pack only appends env variables found in Heroku's config var. Since `SOURCE_VERSION` is different for each build, it can't be maintained in the Heroku's config var. Hence we are adding it to environment variable directory `$ENV_DIR`, so that it can be carried forward. 